### PR TITLE
add support for m1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,9 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.2.8", features = ["derive"] }
 pyo3 = { version = "0.16.5", features = ["auto-initialize"] }
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Compilation would fail on M1 MacOs. source: https://github.com/PyO3/pyo3/pull/1332